### PR TITLE
Fix #42 - Add victory poofer support

### DIFF
--- a/Config.pde
+++ b/Config.pde
@@ -3,12 +3,14 @@ static class Config {
   //static int height = 690;
   static String backendIp = "127.0.0.1";
   static int backendPort = 1075;
-  static int protocolVersion = 0;
+  static int protocolVersion = 1;
 
   //static String gamepadConfiguration = "nes_controller_mac";
   static String gamepadConfiguration = "";
 
   //static String arduinoInputConfiguration = "/dev/cu.usbmodem1411";
   static String arduinoInputConfiguration = "";
+
+  static int pooferDurationMs = 500;
 }
 

--- a/Packet.pde
+++ b/Packet.pde
@@ -13,6 +13,13 @@ class Packet {
     packet += width + "\n";
     packet += height + "\n";
   }
+
+  void addPoofer(boolean active) {
+    for (int i = 0; i < this.width; ++i) {
+      packet += active ? "1" : "0";
+    }
+    packet += "\n";
+  }
   
   void addGridData(boolean[][] gridData) {
     for (int i = 0; i < this.height; ++i) {

--- a/Tetris.pde
+++ b/Tetris.pde
@@ -38,6 +38,7 @@ public void draw() {
   if (currentGame != null) currentGame.update();
   renderer.renderGameState(currentGame);
   udpRenderer.renderGameState(currentGame);
+  if (currentGame != null) currentGame.cleanup();
 }
 
 boolean ctrlPressed = false;

--- a/TetrisGame.pde
+++ b/TetrisGame.pde
@@ -19,6 +19,7 @@ class TetrisGame {
 
   // Scoring properties
   private boolean lastScoreWasSpecial;
+  private boolean justScoredSpecial;
   private boolean lastMoveWasRotate;
   private boolean usedFloorKick;
   private int score;
@@ -53,6 +54,7 @@ class TetrisGame {
 
     level = 1;
     lastScoreWasSpecial = false;
+    justScoredSpecial = false;
     lastMoveWasRotate = false;
     usedFloorKick = false;
   }
@@ -75,6 +77,10 @@ class TetrisGame {
 
   public Grid getGrid() {
     return grid;
+  }
+
+  public boolean getJustScoredSpecial() {
+    return justScoredSpecial;
   }
 
   public int getScore() {
@@ -116,7 +122,7 @@ class TetrisGame {
     if(gameOver) {
       return;
     }
-    
+
     // Pause for "row clearing" animation before the next piece is loaded
     if (animateCount >= 0) {
       animateCount--;
@@ -139,6 +145,11 @@ class TetrisGame {
       if (current != null && current.y == current.final_row)
         currTime = -timer;
     }
+  }
+
+  // Cleanup that needs to happen at the end of a frame
+  public void cleanup() {
+    justScoredSpecial = false;
   }
   
   // Callback for the player pressing "down"
@@ -337,12 +348,12 @@ class TetrisGame {
       case 4: scoreMultiplier = 8; break; // TSpin can fill 3 rows maximum
     }
 
-    boolean specialAchieved = (tspinAchieved || grid.clearedRows.size() == 4);
-    if (specialAchieved && lastScoreWasSpecial) scoreMultiplier *= 1.5;
+    justScoredSpecial = (tspinAchieved || grid.clearedRows.size() == 4);
+    if (justScoredSpecial && lastScoreWasSpecial) scoreMultiplier *= 1.5;
 
     score += 100 * scoreMultiplier * level;
 
-    lastScoreWasSpecial = specialAchieved;
+    lastScoreWasSpecial = justScoredSpecial;
 
     return true;
   }

--- a/UDPRenderer.pde
+++ b/UDPRenderer.pde
@@ -4,8 +4,8 @@ class UDPRenderer {
   
   private UDP udp;
   private Config config;
-  
   private Grid grid;
+  private int pooferStartTime = 0;
   
   UDPRenderer(Config config) {
     this.config = config;
@@ -16,10 +16,16 @@ class UDPRenderer {
   
   void renderGameState(TetrisGame currentGame) {
     Packet packet = new Packet(this.config.protocolVersion, TETRIS_WIDTH, TETRIS_HEIGHT);
-    
+
     if (currentGame == null || currentGame.isGameOver()) {
+      packet.addPoofer(false);
       packet.emptyGrid();
     } else {
+      int currentMillis = millis();
+      if (currentGame.getJustScoredSpecial())
+        pooferStartTime = currentMillis;
+      packet.addPoofer(pooferStartTime > 0 && (currentMillis < pooferStartTime + config.pooferDurationMs));
+
       Tetromino current = currentGame.getCurrent();
       
       boolean[][] flattenGrid = new boolean[TETRIS_WIDTH][TETRIS_HEIGHT];


### PR DESCRIPTION
- Uses configurable length of time (currently 500ms).
- Update the protocol version to 1.
- Add a TetrisGame 'cleanup' phase where 'frame' variables can be cleared.
  This can potentially allow other variables to be added to indicate what
  happened during a certain frame.
